### PR TITLE
fix dead pixman neon build when using new ndks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,7 +211,7 @@ jobs:
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r21e
+          ndk-version: r25b
 
       - uses: actions/setup-java@v1
         with:
@@ -456,7 +456,7 @@ jobs:
         uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r15c
+          ndk-version: r25b
 
       - uses: actions/setup-java@v1
         with:

--- a/project/lib/pixman-files.xml
+++ b/project/lib/pixman-files.xml
@@ -3,11 +3,11 @@
 	<!-- TODO: ARM64 NEON -->
 
 	<!-- <set name="PIXMAN_ARM_SIMD" value="1" if="android || rpi" unless="HXCPP_ARMV7 || HXCPP_ARMV7S || HXCPP_ARM64 || HXCPP_X86" /> -->
-	<set name="PIXMAN_ARM_NEON" value="1" if="HXCPP_ARMV7 || HXCPP_ARMV7S || rpi" unless="ios" />
+	<set name="PIXMAN_ARM_NEON" value="1" if="HXCPP_ARMV7 || HXCPP_ARMV7S || rpi" unless="ios || NDKV22+" />
 
 	<files id="native-toolkit-pixman">
 
-		<compilerflag value="-fno-integrated-as" if="HXCPP_CLANG || NDKV20+" unless="mac || ios" />
+		<compilerflag value="-fno-integrated-as" if="HXCPP_CLANG || NDKV20+" unless="mac || ios || NDKV22+" />
 
 		<compilerflag value="-I${NATIVE_TOOLKIT_PATH}/custom/pixman" />
 		<compilerflag value="-I${NATIVE_TOOLKIT_PATH}/custom/pixman/pixman" />


### PR DESCRIPTION
i forgot to mention that `fno-integrated-as` should be cutted for new ndks too, because of `no such flag: -EL` problem