### PR TITLE
fix libpng sdl error

### DIFF
--- a/project/lib/png-files.xml
+++ b/project/lib/png-files.xml
@@ -38,8 +38,7 @@
 		<file name="${NATIVE_TOOLKIT_PATH}/png/pngwtran.c" />
 		<file name="${NATIVE_TOOLKIT_PATH}/png/pngwutil.c" />
 
-		<!-- Files required only if PNG_ARM_NEON_IMPLEMENTATION == 1 (see pngpriv.h) -->
-		<section if="ios || tvos || HXCPP_ARM64 || HXCPP_ARMV7 || HXCPP_X86 || HXCPP_X86_64">
+		<section if="HXCPP_ARMV7 || HXCPP_ARMV7S || HXCPP_ARM64">
 
 			<file name="${NATIVE_TOOLKIT_PATH}/png/arm/arm_init.c" />
 			<file name="${NATIVE_TOOLKIT_PATH}/png/arm/filter_neon_intrinsics.c" />

--- a/project/lib/png-files.xml
+++ b/project/lib/png-files.xml
@@ -39,7 +39,7 @@
 		<file name="${NATIVE_TOOLKIT_PATH}/png/pngwutil.c" />
 
 		<!-- Files required only if PNG_ARM_NEON_IMPLEMENTATION == 1 (see pngpriv.h) -->
-		<section if="ios || tvos || HXCPP_ARM64">
+		<section if="ios || tvos || HXCPP_ARM64 || HXCPP_ARMV7 || HXCPP_X86 || HXCPP_X86_64">
 
 			<file name="${NATIVE_TOOLKIT_PATH}/png/arm/arm_init.c" />
 			<file name="${NATIVE_TOOLKIT_PATH}/png/arm/filter_neon_intrinsics.c" />


### PR DESCRIPTION
when one of my testers with armv7 tried to launch the app, this happened
![Screenshot_20221029_152149_com shadowmario psychengine](https://user-images.githubusercontent.com/71220271/198851443-61d6136e-508c-4f51-ae2f-9972e843f769.jpg)
i searched a bit and found that neon thing in png applies only for arm64 and working only arm64, i changed to all arches and it worked, as i understand it, that error appears on all ndks.